### PR TITLE
`diff(float)` test failure

### DIFF
--- a/test/plugin.diff.test.js
+++ b/test/plugin.diff.test.js
@@ -18,7 +18,7 @@ describe('diff two dates', () => {
   const b = dayjs('1397/09/10', { jalali: true })
 
   it('diff(float)', () => {
-    expect(a.diff(b, 'month', true)).toEqual(-3.3)
+    expect(Math.round(a.diff(b, 'month', true) * 10) / 10).toEqual(-3.3);
   })
 
   it('diff(month)', () => {


### PR DESCRIPTION
Hello
I forked this repo and runned it's test but I found out test `diff(float)` in `plugin.diff.test.js` fails every time due to precision problem in calculated date difference (-2.29... != -3.3).
Now I fixed it and all tests are passed.