### PR TITLE
Add `isJalali` to dayjs factory

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -60,6 +60,10 @@ export default (o, Dayjs, dayjs) => {
     return that;
   };
 
+  dayjs.isJalali = function () {
+    return $isJalali(this);
+  };
+  
   proto.isJalali = function () {
     return $isJalali(this);
   };

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -38,3 +38,11 @@ test('keep instance calendar on manipulation', () => {
   expect(dayjs(date).add(1, 'month').$C).toEqual('jalali')
   expect(dayjs(date).add(1, 'month').add(1, 'month').isJalali()).toEqual(true)
 })
+
+test('is jalali', () => {
+  dayjs.calendar('gregory')
+  expect(dayjs.isJalali()).toEqual(false)
+
+  dayjs.calendar('jalali')
+  expect(dayjs.isJalali()).toEqual(true)
+})


### PR DESCRIPTION
I found out `isJalali` only exist in `dayjs` instances and not dayjs factory and now I added it to factory for when we want to check that calendar is jalali without dayjs instance creation.